### PR TITLE
Save dimension in inicial rate creation

### DIFF
--- a/lib/seems_rateable/model.rb
+++ b/lib/seems_rateable/model.rb
@@ -7,7 +7,8 @@ module SeemsRateable
 	if !has_rated?(user_id, dimension)   
 	 self.rates.create do |r| 
 	  r.stars = stars
-	  r.rater_id = user_id 
+	  r.rater_id = user_id
+	  r.dimension = dimension
 	 end
 	 update_overall_average_rating(stars, dimension) 
 	elsif has_rated?(user_id, dimension) && can_update?


### PR DESCRIPTION
When creating a rate for the first time dimension wasn't being saved, for that reason !has_rated could not find the intended record and a new rate was always being created.

@csbg also helped in the resolution of this problem.
